### PR TITLE
Updated mapping_definitions.sh for ES6

### DIFF
--- a/channelfinder/src/main/resources/mapping_definitions.sh
+++ b/channelfinder/src/main/resources/mapping_definitions.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###
 # #%L
 # ChannelFinder Directory Service
+# %%
+# Copyright (C) 2020        Lawrence Berkeley National Laboratory
 # %%
 # Copyright (C) 2010 - 2016 Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
 # %%
@@ -13,68 +15,81 @@
 
 # The mapping definition for the Indexes associated with the channelfinder v2
 
+function print_help()
+{
+    local type=$1; shift;
+    local index=$1; shift;
+    printf "\n>>> %s : %s ....\n" "$type" "$index";
+}
 
 #Create the Index
+print_help "index" "tags"
 curl -XPUT 'http://localhost:9200/tags'
+
 #Set the mapping
-curl -XPUT 'http://localhost:9200/tags/_mapping/tag' -d'
+print_help "mapping" "tags"
+curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/tags/_mapping/tag' -d'
 {
   "tag" : {
     "properties" : {
       "name" : {
-        "type" : "string"
+        "type" : "text"
       },
       "owner" : {
-        "type" : "string"
+        "type" : "text"
       }
     }
   }
 }'
 
+print_help "index" "properties"
 curl -XPUT 'http://localhost:9200/properties'
-curl -XPUT 'http://localhost:9200/properties/_mapping/property' -d'
+print_help "mapping" "properties"
+curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/properties/_mapping/property' -d'
 {
   "property" : {
     "properties" : {
       "name" : {
-        "type" : "string"
+        "type" : "text"
       },
       "owner" : {
-        "type" : "string"
+        "type" : "text"
       }
     }
   }
 }'
 
+print_help "index" "channelfinder"
 curl -XPUT 'http://localhost:9200/channelfinder'
-curl -XPUT 'http://localhost:9200/channelfinder/_mapping/channel' -d'
+print_help "mapping" "channelfinder"
+curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/channelfinder/_mapping/channel' -d'
 {
   "channel" : {
     "properties" : {
       "name" : {
-        "type" : "string",
+        "type" : "text",
         "analyzer" : "whitespace"
       },
       "owner" : {
-        "type" : "string",
+        "type" : "text",
         "analyzer" : "whitespace"
       },
       "script" : {
-        "type" : "string"
+        "type" : "text"
       },
       "properties" : {
         "type" : "nested",
         "include_in_parent" : true,
         "properties" : {
           "name" : {
-            "type" : "string",
+            "type" : "text",
             "analyzer" : "whitespace"
           },
           "owner" : {
-            "type" : "string"
+            "type" : "text"
           },
           "value" : {
-            "type" : "string",
+            "type" : "text",
             "analyzer" : "whitespace"
           }
         }
@@ -84,11 +99,11 @@ curl -XPUT 'http://localhost:9200/channelfinder/_mapping/channel' -d'
         "include_in_parent" : true,
         "properties" : {
           "name" : {
-            "type" : "string",
+            "type" : "text",
             "analyzer" : "whitespace"
           },
           "owner" : {
-            "type" : "string",
+            "type" : "text",
             "analyzer" : "whitespace"
           }
         }
@@ -96,3 +111,5 @@ curl -XPUT 'http://localhost:9200/channelfinder/_mapping/channel' -d'
     }
   }
 }'
+
+printf "\n";


### PR DESCRIPTION
Hi Kunal,

   Here are three changes for this script as follows 
  
- added ` -H 'Content-Type: application/json'` in curl command in order to remove the following error:
```
"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406
```
- replaced `string` with `text` with the full searchable text, because the string type was removed since ES 5. 

- added the little cosmetic print command to distinguish the output of curl in a terminal.

Please let me know what you think. 